### PR TITLE
Added option to override default charset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## ???
+### Added
+- Option to override the default character set.
+
+
 ## 0.2.0 - 2020-12-15
 ### Added
 - CPU and GPU accelerated multi-thread name breaking support.

--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ Invoke-MpqNameBreaking -HashA 0x26BBF734u -HashB 0x2C785839u `
     -Prefix 'MONSTERS\MEGA\' -AdditionalChars '.' -Verbose
 ```
 
-The default charset used for the name breaking is `0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_-`  
-It can be extended with the `-AdditionalChars` parameter.
+The default charset used for the name breaking is `0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_-`.  
+It can be extended with the `-AdditionalChars` parameter, or overridden with the `-Charset` parameter.
+
 
 
 ## Build

--- a/source/MpqNameBreaker/InvokeMpqNameBreaking.cs
+++ b/source/MpqNameBreaker/InvokeMpqNameBreaking.cs
@@ -1,14 +1,10 @@
 ﻿using System;
 using System.Text;
-using System.Collections;
-using System.Diagnostics;
 using System.Management.Automation;
-using System.Management.Automation.Runspaces;
 using MpqNameBreaker.NameGenerator;
 using MpqNameBreaker.Mpq;
 using ILGPU;
 using ILGPU.Runtime;
-//using System.Collections.Immutable;
 
 namespace MpqNameBreaker
 {
@@ -47,7 +43,14 @@ namespace MpqNameBreaker
             Position = 3,
             ValueFromPipelineByPropertyName = true)]
         [AllowEmptyString()]
-        public string AdditionalChars { get; set; }
+        public string AdditionalChars { get; set; } = "";
+
+        [Parameter(
+            Mandatory = false,
+            Position = 3,
+            ValueFromPipelineByPropertyName = true)]
+        [AllowEmptyString()]
+        public string Charset { get; set; } = BruteForceBatches.DefaultCharset;
 
         [Parameter(
             Mandatory = false,
@@ -123,11 +126,7 @@ namespace MpqNameBreaker
             }
 
             // Initialize brute force batches name generator
-            if( this.MyInvocation.BoundParameters.ContainsKey("AdditionalChars") )
-                _bruteForceBatches = new BruteForceBatches( BatchSize, BatchCharCount, AdditionalChars );
-            else
-                _bruteForceBatches = new BruteForceBatches( BatchSize, BatchCharCount );
-
+            _bruteForceBatches = new BruteForceBatches( BatchSize, BatchCharCount, AdditionalChars, Charset );
             _bruteForceBatches.Initialize();
 
             // Load kernel (GPU function)

--- a/source/MpqNameBreaker/NameGenerator/BruteForceBatches.cs
+++ b/source/MpqNameBreaker/NameGenerator/BruteForceBatches.cs
@@ -7,10 +7,9 @@ namespace MpqNameBreaker.NameGenerator
     {
         // Constants
         public const int MaxGeneratedChars = 16;
-        //public const string Charset = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_-.()\\";
-        // ".\\()"
+        public const string DefaultCharset = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_-";
 
-        public string Charset { get; private set; }
+        public string Charset { get; private set; } = DefaultCharset;
         public byte[] CharsetBytes { get; private set; }
 
 
@@ -51,40 +50,29 @@ namespace MpqNameBreaker.NameGenerator
             } 
         }
 
-        public bool Initialized { get; private set; }
+        public bool Initialized { get; private set; } = false;
 
-        public bool FirstBatch { get; private set; }
-        public int BatchNumber { get; private set; }
+        public bool FirstBatch { get; private set; } = true;
+        public int BatchNumber { get; private set; } = 0;
 
         // Fields
-        private int _generatedCharIndex;
+        private int _generatedCharIndex = 0;
         private int[] _nameCharsetIndexes;
 
-
-        
         // Constructors
         public BruteForceBatches()
         {
-            Initialized = false;
-            Charset = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_-";
             CharsetBytes = Encoding.ASCII.GetBytes( Charset.ToUpper() );
-            FirstBatch = true;
-            BatchNumber = 0;
-            _generatedCharIndex = 0;
         }
 
-        public BruteForceBatches( int size, int charCount ) : this()
+        public BruteForceBatches( int size, int charCount, string additionalChars = "", string charset = DefaultCharset)
         {
             this.BatchSize = size;
             this.BatchItemCharCount = charCount;
+            this.BatchNameSeedCharsetIndexes = new int[size, MaxGeneratedChars];
 
-            BatchNameSeedCharsetIndexes = new int[ size, MaxGeneratedChars ];
-        }
-
-        public BruteForceBatches( int size, int charCount, string additionalChars ) : this( size, charCount )
-        {
-            Charset += additionalChars;
-            CharsetBytes = Encoding.ASCII.GetBytes( Charset.ToUpper() );
+            this.Charset = charset + additionalChars;
+            this.CharsetBytes = Encoding.ASCII.GetBytes( Charset.ToUpper() );
         }
 
         // Methods


### PR DESCRIPTION
Allows overriding the default charset.

i.e. if you know there won't be numbers, hyphens, or characters like `q` or `z` in the name.
